### PR TITLE
fix(core): add support for generic and common consumer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "loopback4-kafka-client",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "loopback4-kafka-client",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@loopback/boot": "^6.1.0",

--- a/src/__tests__/acceptance/fixtures/consumer/consumer-app.ts
+++ b/src/__tests__/acceptance/fixtures/consumer/consumer-app.ts
@@ -8,6 +8,8 @@ import {KafkaClientBindings} from '../../../../keys';
 import {KafkaClientStub} from '../../../stubs';
 import {StartConsumer} from './start-consumer.extension';
 import {StopConsumer} from './stop-consumer.extension';
+import {CommonConsumer} from './shared-consumer.extension';
+import {GenericConsumer} from './generic-consumer.extension';
 
 export class ConsumerApp extends BootMixin(
   ServiceMixin(RepositoryMixin(RestApplication)),
@@ -26,6 +28,8 @@ export class ConsumerApp extends BootMixin(
     this.component(KafkaClientComponent);
     this.service(StartConsumer);
     this.service(StopConsumer);
+    this.service(CommonConsumer);
+    this.service(GenericConsumer);
 
     this.projectRoot = __dirname;
     // Customize @loopback/boot Booter Conventions here

--- a/src/__tests__/acceptance/fixtures/consumer/generic-consumer.extension.ts
+++ b/src/__tests__/acceptance/fixtures/consumer/generic-consumer.extension.ts
@@ -1,0 +1,15 @@
+import {inject, injectable} from '@loopback/core';
+import {asConsumer} from '../../../../keys';
+import {TestStream} from '../stream';
+import {IGenericConsumer, StreamHandler} from '../../../../types';
+import {Topics} from '../topics.enum';
+import {Events} from '../events.enum';
+
+@injectable(asConsumer)
+export class GenericConsumer implements IGenericConsumer<TestStream> {
+  constructor(
+    @inject('eventHandler.generic')
+    public handler: StreamHandler<TestStream, Events>,
+  ) {}
+  topic: Topics.First = Topics.First;
+}

--- a/src/__tests__/acceptance/fixtures/consumer/shared-consumer.extension.ts
+++ b/src/__tests__/acceptance/fixtures/consumer/shared-consumer.extension.ts
@@ -1,0 +1,16 @@
+import {inject, injectable} from '@loopback/core';
+import {asConsumer} from '../../../../keys';
+import {TestStream} from '../stream';
+import {ISharedConsumer, StreamHandler} from '../../../../types';
+import {Topics} from '../topics.enum';
+import {Events} from '../events.enum';
+
+@injectable(asConsumer)
+export class CommonConsumer implements ISharedConsumer<TestStream> {
+  constructor(
+    @inject('eventHandler.common')
+    public handler: StreamHandler<TestStream, Events>,
+  ) {}
+  topic: Topics.First = Topics.First;
+  events = [Events.pause, Events.reset];
+}

--- a/src/__tests__/acceptance/fixtures/consumer/start-consumer.extension.ts
+++ b/src/__tests__/acceptance/fixtures/consumer/start-consumer.extension.ts
@@ -1,12 +1,13 @@
-import {consumer} from '../../../../decorators';
+import {injectable} from '@loopback/core';
 import {eventHandler} from '../../../../decorators/handler.decorator';
-import {StreamHandler} from '../../../../types';
+import {asConsumer} from '../../../../keys';
+import {IConsumer, StreamHandler} from '../../../../types';
 import {Events} from '../events.enum';
 import {TestStream} from '../stream';
 import {Topics} from '../topics.enum';
 
-@consumer<TestStream, Events.start>()
-export class StartConsumer {
+@injectable(asConsumer)
+export class StartConsumer implements IConsumer<TestStream, Events.start> {
   constructor(
     @eventHandler<TestStream>(Events.start)
     public handler: StreamHandler<TestStream, Events.start>,

--- a/src/__tests__/acceptance/fixtures/consumer/stop-consumer.extension.ts
+++ b/src/__tests__/acceptance/fixtures/consumer/stop-consumer.extension.ts
@@ -1,11 +1,12 @@
-import {consumer} from '../../../../decorators';
+import {injectable} from '@loopback/core';
 import {eventHandler} from '../../../../decorators/handler.decorator';
+import {asConsumer} from '../../../../keys';
 import {IConsumer, StreamHandler} from '../../../../types';
 import {Events} from '../events.enum';
 import {TestStream} from '../stream';
 import {Topics} from '../topics.enum';
 
-@consumer<TestStream, Events.stop>()
+@injectable(asConsumer)
 export class StopConsumer implements IConsumer<TestStream, Events.stop> {
   constructor(
     @eventHandler<TestStream>(Events.stop)

--- a/src/__tests__/acceptance/fixtures/events.enum.ts
+++ b/src/__tests__/acceptance/fixtures/events.enum.ts
@@ -1,4 +1,7 @@
 export enum Events {
   start = 'start',
   stop = 'stop',
+  reset = 'reset',
+  pause = 'pause',
+  close = 'close',
 }

--- a/src/__tests__/acceptance/fixtures/stream.ts
+++ b/src/__tests__/acceptance/fixtures/stream.ts
@@ -8,5 +8,8 @@ export interface TestStream extends IStreamDefinition {
   messages: {
     [Events.start]: StartEvent;
     [Events.stop]: StopEvent;
+    [Events.reset]: {};
+    [Events.pause]: {};
+    [Events.close]: {};
   };
 }

--- a/src/__tests__/acceptance/test-helper.ts
+++ b/src/__tests__/acceptance/test-helper.ts
@@ -13,6 +13,8 @@ export async function setupConsumerApplication(
   kafkaStub: KafkaClientStub,
   startHandler: StreamHandler<TestStream, Events.start>,
   stopHandler: StreamHandler<TestStream, Events.stop>,
+  commonHandler: StreamHandler<TestStream, Events>,
+  genericHandler: StreamHandler<TestStream, Events>,
   logger: ILogger,
 ): Promise<Application> {
   const restConfig = givenHttpServerConfig({});
@@ -29,6 +31,8 @@ export async function setupConsumerApplication(
   app
     .bind(eventHandlerKey<TestStream, Events.stop>(Events.stop))
     .to(stopHandler);
+  app.bind('eventHandler.common').to(commonHandler);
+  app.bind('eventHandler.generic').to(genericHandler);
   app.bind(LOGGER.LOGGER_INJECT).to(logger);
   await app.boot();
   await app.start();

--- a/src/__tests__/stubs/kafka.stub.ts
+++ b/src/__tests__/stubs/kafka.stub.ts
@@ -47,8 +47,14 @@ export class KafkaClientStub {
       disconnect: async () => {
         delete this.subscribers[id];
       },
-      subscribe: async (params: {topic: string}) => {
-        this.subscribers[id].topics.push(params.topic);
+      subscribe: async (params: {topic?: string; topics?: string[]}) => {
+        if (params.topic) {
+          this.subscribers[id].topics.push(params.topic);
+        } else if (params.topics) {
+          this.subscribers[id].topics.push(...params.topics);
+        } else {
+          // do nothing
+        }
       },
       run: async (params: {eachMessage: (message: AnyObject) => void}) => {
         this.subscribers[id].handler = params.eachMessage;

--- a/src/component.ts
+++ b/src/component.ts
@@ -36,7 +36,8 @@ export class KafkaClientComponent implements Component {
     }
     app
       .bind(KafkaClientBindings.ProducerFactory)
-      .toProvider(KafkaProducerFactoryProvider);
+      .toProvider(KafkaProducerFactoryProvider)
+      .inScope(BindingScope.SINGLETON);
 
     app.service(KafkaConsumerService);
 

--- a/src/error-keys.ts
+++ b/src/error-keys.ts
@@ -5,4 +5,6 @@ export enum KafkaErrorKeys {
   EventWithoutValue = 'EventWithoutValue',
   UnhandledEvent = 'Unhandled Event',
   PublishFailed = 'Publish Failed',
+  MultipleGenericConsumers = 'Multiple Generic Consumers',
+  HandleByGenericConsumer = 'Handled By Generic Consumer',
 }

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -1,8 +1,9 @@
 import {BindingKey, BindingTemplate, extensionFor} from '@loopback/core';
-import {ConsumerConfig, Kafka, ProducerConfig} from 'kafkajs';
+import {Kafka, ProducerConfig} from 'kafkajs';
 import {KafkaClientComponent} from './component';
 import {KafkaConsumerService} from './services/kafka-consumer.service';
 import {
+  ConsumerConfig,
   IStreamDefinition,
   Producer,
   ProducerFactoryType,

--- a/src/providers/kafka-producer-factory.provider.ts
+++ b/src/providers/kafka-producer-factory.provider.ts
@@ -1,6 +1,6 @@
 import {inject, Provider} from '@loopback/core';
 import {ILogger, LOGGER} from '@sourceloop/core';
-import {Kafka, ProducerConfig} from 'kafkajs';
+import {CompressionTypes, Kafka, ProducerConfig} from 'kafkajs';
 import {KafkaErrorKeys} from '../error-keys';
 import {KafkaClientBindings} from '../keys';
 import {IStreamDefinition, ProducerFactoryType} from '../types';
@@ -33,6 +33,7 @@ export class KafkaProducerFactoryProvider<T extends IStreamDefinition>
             await producer.connect();
             await producer.send({
               topic: topic,
+              compression: CompressionTypes.GZIP,
               messages: payload.map(message => ({
                 key,
                 value: JSON.stringify({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,14 @@
-import {KafkaConfig} from 'kafkajs';
+import {KafkaConfig, ConsumerConfig as KafkajsConsumerConfig} from 'kafkajs';
 
 export interface KafkaClientOptions {
   connection: KafkaConfig;
   topics?: string[];
   initObservers?: boolean;
 }
+
+export type ConsumerConfig = {
+  alwaysRunGenericConsumer?: boolean;
+} & KafkajsConsumerConfig;
 
 /* Defining the interface for the stream definition. */
 export interface IStreamDefinition {
@@ -16,6 +20,15 @@ export type TopicForStream<Stream extends IStreamDefinition> = Stream['topic'];
 export type EventsInStream<Stream extends IStreamDefinition> =
   keyof Stream['messages'];
 
+export type ConsumerType<
+  Stream extends IStreamDefinition,
+  K extends EventsInStream<Stream>,
+> = IConsumer<Stream, K> | ISharedConsumer<Stream> | IGenericConsumer<Stream>;
+
+export interface IBaseConsumer<Stream extends IStreamDefinition> {
+  handler: StreamHandler<Stream, EventsInStream<Stream>>;
+}
+
 export interface IConsumer<
   Stream extends IStreamDefinition,
   K extends EventsInStream<Stream>,
@@ -23,6 +36,41 @@ export interface IConsumer<
   topic: TopicForStream<Stream>;
   event: K;
   handler: StreamHandler<Stream, K>;
+}
+
+export interface ISharedConsumer<Stream extends IStreamDefinition> {
+  topic: TopicForStream<Stream>;
+  events: EventsInStream<Stream>[];
+  handler: StreamHandler<Stream, EventsInStream<Stream>>;
+}
+
+export interface IGenericConsumer<Stream extends IStreamDefinition> {
+  topic: TopicForStream<Stream>;
+  handler: StreamHandler<Stream, EventsInStream<Stream>>;
+}
+
+export function isGenericConsumer<
+  Stream extends IStreamDefinition,
+  K extends EventsInStream<Stream>,
+>(consumer: ConsumerType<Stream, K>): consumer is IGenericConsumer<Stream> {
+  return !(
+    (consumer as ISharedConsumer<Stream>).events ||
+    (consumer as IConsumer<Stream, K>).event
+  );
+}
+
+export function isSharedConsumer<
+  Stream extends IStreamDefinition,
+  K extends EventsInStream<Stream>,
+>(consumer: ConsumerType<Stream, K>): consumer is ISharedConsumer<Stream> {
+  return !!(consumer as ISharedConsumer<Stream>).events;
+}
+
+export function isConsumer<
+  Stream extends IStreamDefinition,
+  K extends EventsInStream<Stream>,
+>(consumer: ConsumerType<Stream, K>): consumer is IConsumer<Stream, K> {
+  return !!(consumer as IConsumer<Stream, K>).event;
 }
 
 export interface Producer<Stream extends IStreamDefinition> {


### PR DESCRIPTION
- added support for a generic and common consumer so that a user can implement a common consumer for multiple events or all events -
     -  `ISharedConsumer` : implement this if you want a common consumer for multiple events
     -   `IGenericConsumer` : implement this if you want a common consumer for all events in a stream

Fixes #30

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
